### PR TITLE
added multiple 'path' push_files/pull_files

### DIFF
--- a/tasks/wordpressdeploy.js
+++ b/tasks/wordpressdeploy.js
@@ -41,13 +41,13 @@ module.exports = function(grunt) {
     util.db_dump(local_options, local_backup_paths);
 
     // Search and Replace database refs
-    util.db_adapt(local_options, target_options, local_backup_paths.file);
+    util.db_adapt(local_options.url, target_options.url, local_backup_paths.file);
 
     // Dump target DB
     util.db_dump(target_options, target_backup_paths);
 
     // Import dump to target DB
-    // util.db_import(target_options, local_backup_paths.file);
+    util.db_import(target_options, local_backup_paths.file);
 
     grunt.log.subhead("Operations completed");
   });
@@ -79,8 +79,7 @@ module.exports = function(grunt) {
     // Dump Target DB
     util.db_dump(target_options, target_backup_paths );
 
-    grunt.log.subhead("Adapting sqldump to target");
-    util.db_adapt(target_options,local_options,target_backup_paths.file);
+    util.db_adapt(target_options.url,local_options.url,target_backup_paths.file);
 
     // Backup Local DB
     util.db_dump(local_options, local_backup_paths);
@@ -117,8 +116,17 @@ module.exports = function(grunt) {
       to: target_options.path,
       exclusions: exclusions
     };
-
-    util.rsync_push(config);
+    
+    if (local_options.path !== null && typeof local_options.path === 'object') {
+      for (var key in local_options.path) {
+        config.from = local_options.path[key];
+        config.to = target_options.path[key];
+        util.rsync_push(config);
+      }
+    } else {
+      util.rsync_push(config);
+    }
+    
   });
 
   /**
@@ -148,6 +156,14 @@ module.exports = function(grunt) {
       exclusions: exclusions
     };
 
-    util.rsync_pull(config);
+    if (local_options.path !== null && typeof local_options.path === 'object') {
+      for (var key in local_options.path) {
+        config.from = local_options.path[key];
+        config.to = target_options.path[key];
+        util.rsync_pull(config);
+      }
+    } else {
+      util.rsync_pull(config);
+    }
   });
 };


### PR DESCRIPTION
Added a check for `local_options.path`, if it's an object with multiple paths the rsync commands are repeated for each one of them. If it's a string, the single rsync command is run.

Even though it's documented in the repository and the examples show you could have multiple paths, it wasn't actually working.
